### PR TITLE
Adding watch support to the 'host' command

### DIFF
--- a/docs/source/cli/index.md
+++ b/docs/source/cli/index.md
@@ -51,14 +51,15 @@ The build command will render all `index.md` files into corresponding `index.htm
 
 ## `host` sub command
 
-The host sub command starts a simple HTML web server. Useful for local preview during development or even authoring.
+The host sub command starts a simple HTML web server. Useful for local preview during development or even authoring. If you update markdown files, the content will automatically be rebuilt so you can just refresh the browser.
 
 ```
-chloroplast host --out path/to/html
+chloroplast host --root path/to/root --out path/to/html 
 ```
 
-You can just press the enter key to end this task at any time. For simplicity's sake, you can also just run this command in a separate terminal window and leave it running. That way, as you rebuild the content or update 
-the front-end styles, you can just refresh the browser after that buil has completed.
+You can just press the enter key to end this task after stopping the web host with ctrl+c at any time. 
+
+If you are updating razor templates, you can also just run this command in a separate terminal window and leave it running. That way, as you run the full `build` subcommand, the content and front-end styles will update, and you can just refresh the browser after that build has completed.
 
 ### parameters
 

--- a/toolsrc/Chloroplast.Core/Content/ContentArea.cs
+++ b/toolsrc/Chloroplast.Core/Content/ContentArea.cs
@@ -24,37 +24,42 @@ namespace Chloroplast.Core.Content
             // individual files
 
             var fileConfigs = config.GetSection ("files");
-            foreach (var fileConfig in fileConfigs.GetChildren ())
+            if (fileConfigs != null)
             {
-                var area = new IndividualContentArea
+                foreach (var fileConfig in fileConfigs.GetChildren ())
                 {
-                    SourcePath = rootDirectory.CombinePath (fileConfig["source_file"]),
-                    TargetPath = outDirectory.CombinePath (fileConfig["output_folder"].NormalizePath(toLower: normalizePaths)),
-                    RootRelativePath = fileConfig["output_folder"].Replace ("index.html", "").NormalizePath(toLower: normalizePaths)
-                };
+                    var area = new IndividualContentArea
+                    {
+                        SourcePath = rootDirectory.CombinePath (fileConfig["source_file"]),
+                        TargetPath = outDirectory.CombinePath (fileConfig["output_folder"].NormalizePath (toLower: normalizePaths)),
+                        RootRelativePath = fileConfig["output_folder"].Replace ("index.html", "").NormalizePath (toLower: normalizePaths)
+                    };
 
-                yield return area;
+                    yield return area;
+                }
             }
 
             // areas
             var areaConfigs = config.GetSection ("areas");
 
-
-            foreach (var areaConfig in areaConfigs.GetChildren ())
+            if (areaConfigs != null)
             {
-                var area = new GroupContentArea
+                foreach (var areaConfig in areaConfigs.GetChildren ())
                 {
-                    SourcePath = rootDirectory.CombinePath (areaConfig["source_folder"]),
+                    var area = new GroupContentArea
+                    {
+                        SourcePath = rootDirectory.CombinePath (areaConfig["source_folder"]),
 
-                    TargetPath = outDirectory.CombinePath (areaConfig["output_folder"].NormalizePath(toLower: normalizePaths)),
-                    RootRelativePath = areaConfig["output_folder"].Replace ("index.html", "").NormalizePath (toLower: normalizePaths),
-                    NormalizePaths = normalizePaths,
-                    AreaType = areaConfig["type"]
-                };
+                        TargetPath = outDirectory.CombinePath (areaConfig["output_folder"].NormalizePath (toLower: normalizePaths)),
+                        RootRelativePath = areaConfig["output_folder"].Replace ("index.html", "").NormalizePath (toLower: normalizePaths),
+                        NormalizePaths = normalizePaths,
+                        AreaType = areaConfig["type"]
+                    };
 
-                // TODO: validate values
+                    // TODO: validate values
 
-                yield return area;
+                    yield return area;
+                }
             }
         }
     }

--- a/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
@@ -18,11 +18,13 @@ namespace Chloroplast.Core.Rendering
 
         public async Task AddTemplateAsync (string templatePath)
         {
-            Chloroplast.Core.Loaders.EcmaXml.Namespace ns = new Chloroplast.Core.Loaders.EcmaXml.Namespace ();
-            Console.WriteLine (ns.ToString ());
             string fileName = Path.GetFileNameWithoutExtension (templatePath);
-            templates[fileName] = Razor.Compile (await File.ReadAllTextAsync (templatePath));
-
+            if (!templates.ContainsKey (fileName))
+            {
+                Chloroplast.Core.Loaders.EcmaXml.Namespace ns = new Chloroplast.Core.Loaders.EcmaXml.Namespace ();
+                Console.WriteLine (ns.ToString ());
+                templates[fileName] = Razor.Compile (await File.ReadAllTextAsync (templatePath));
+            }
         }
 
         public async Task InitializeAsync (IConfigurationRoot config)

--- a/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
+++ b/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
@@ -9,7 +9,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
 
-    <Version>0.5.3</Version>
+    <Version>0.5.4</Version>
     <Authors>Wilderness Labs</Authors>
     <Company>Wilderness Labs</Company>
     <PackageDescription>Markdown-based static site generator</PackageDescription>

--- a/toolsrc/Chloroplast.Tool/Commands/HostCommand.cs
+++ b/toolsrc/Chloroplast.Tool/Commands/HostCommand.cs
@@ -10,12 +10,18 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.FileProviders;
 using System.IO;
 using Chloroplast.Core;
+using Microsoft.Extensions.Primitives;
+using System.Linq;
 
 namespace Chloroplast.Tool.Commands
 {
     public class HostCommand : ICliCommand
     {
         string rootPath;
+        string pathToUse;
+        IConfigurationRoot rootconfig;
+        List<FileSystemWatcher> watchers = new List<FileSystemWatcher> ();
+        List<string> areaSourcePaths = new List<string> ();
 
         public HostCommand ()
         {
@@ -25,9 +31,12 @@ namespace Chloroplast.Tool.Commands
 
         public async Task<IEnumerable<Task>> RunAsync (IConfigurationRoot config)
         {
-            string pathToUse;
+            this.rootconfig = config;
             var outPath = config["out"].NormalizePath ();
             this.rootPath = config["root"].NormalizePath ();
+
+            Console.WriteLine ($"out: " + outPath);
+            Console.WriteLine ($"root: " + rootPath);
 
             if (!string.IsNullOrWhiteSpace(outPath))
             {
@@ -59,7 +68,7 @@ namespace Chloroplast.Tool.Commands
                      webBuilder.UseUrls ("http://localhost:5000");
                      webBuilder.UseStartup<Startup> ();
                  })
-                .UseConsoleLifetime ()
+                .UseConsoleLifetime (c => c.SuppressStatusMessages = true)
                 .Build ();
             //using (host)
             {
@@ -81,21 +90,47 @@ namespace Chloroplast.Tool.Commands
                 return new[] {Task.Factory.StartNew(() =>
                     {
 
-                        Console.WriteLine ("watching: " + this.rootPath);
-                        using var watcher = new FileSystemWatcher(this.rootPath);
+                        var areaConfigs = this.rootconfig.GetSection ("areas");
+                        
+                        if (areaConfigs != null)
+                        {
+                            foreach (var areaConfig in areaConfigs.GetChildren ())
+                            {
+                                var areaSource = areaConfig["source_folder"];
+                                this.areaSourcePaths.Add(areaSource);
+                                var areaSourcePath = this.rootPath.CombinePath (areaSource);
+                                Console.WriteLine ("watching: " + areaSourcePath);
+                                var watcher = new FileSystemWatcher(areaSourcePath);
 
-                        watcher.NotifyFilter = NotifyFilters.LastWrite
-                                             | NotifyFilters.Size;
+                                watcher.NotifyFilter = NotifyFilters.LastWrite
+                                                        | NotifyFilters.Size;
 
-                        watcher.Changed += Watcher_Changed;
-                        watcher.Error += Watcher_Error;;
+                                watcher.Changed += Watcher_Changed;
+                                watcher.Error += Watcher_Error;
 
-                        watcher.Filter = "*.md";
-                        watcher.IncludeSubdirectories = true;
-                        watcher.EnableRaisingEvents = true;
+                                // TODO: consider changing filter so we copy over static assets
+                                watcher.Filter = "*.md";
+                                watcher.IncludeSubdirectories = true;
+                                watcher.EnableRaisingEvents = true;
+                                watchers.Add(watcher);
+                            }
 
+                        }
+                        else
+                        {
+                            Console.WriteLine("no source areas to watch for changes in SiteConfig.yml");
+                        }
+
+                        Console.WriteLine("Press Enter to Quit Host");
                         Console.ReadLine();
-
+                        // TODO: need a better story for disposing this in case of an error
+                        foreach(var w in watchers)
+                        {
+                            w.Changed -= Watcher_Changed;
+                            w.Error -= Watcher_Error;
+                            w.Dispose();
+                        }
+                        watchers.Clear();
                         host.Dispose();
                 }) };
             }
@@ -116,6 +151,7 @@ namespace Chloroplast.Tool.Commands
             }
         }
 
+        bool running = false;
 
         private void Watcher_Changed (object sender, FileSystemEventArgs e)
         {
@@ -123,7 +159,112 @@ namespace Chloroplast.Tool.Commands
             {
                 return;
             }
+            if (this.running)
+            {
+                Console.WriteLine ($"File changed during build, not rebuilt: {e.FullPath}");
+                // TODO: add to waiting queue
+                return;
+            }
+
+            // TODO: implement a custom IConfigurationRoot that points to this one changed file, and call FullBuildCommand
+            WatcherConfig config = new WatcherConfig ();
+            config["out"] = this.pathToUse;
+            config["root"] = this.rootPath;
+            config["force"] = "true";
+
+
+            if (string.IsNullOrEmpty (rootconfig["templates_folder"]))
+            {
+                string[] siteFramePaths = Directory.GetFiles (this.rootPath, "SiteFrame.cshtml", SearchOption.AllDirectories);
+                if (!siteFramePaths.Any ())
+                {
+                    throw new ChloroplastException ($":( Could not find 'SiteFrame.cshtml' in {this.rootPath}");
+                }
+
+                config["templates_folder"] = Path.GetDirectoryName (siteFramePaths.First ());
+            }
+            else
+                config["templates_folder"] = rootconfig["templates_folder"];
+
+            string relativePath = e.FullPath.Replace (this.rootPath, string.Empty);
+
+            string relativeOut = relativePath;
+            if (relativeOut.EndsWith (".md"))
+                relativeOut = Path.Combine (
+                        Path.GetDirectoryName (relativePath),
+                        "index.html"
+                    );
+            foreach (var areaSourcePath in this.areaSourcePaths)
+            {
+                relativeOut = relativeOut.Replace (areaSourcePath, string.Empty);
+            }
+
+            config.AddSection ("files", new WatcherConfig (new Dictionary<string, string>
+            {
+                { "source_file", relativePath },
+                { "output_folder",  relativeOut }
+            }));
+
+            FullBuildCommand fullBuild = new FullBuildCommand ();
+
             Console.WriteLine ($"Changed: {e.FullPath}");
+            this.running = true;
+            var tasks = fullBuild.RunAsync (config);
+            tasks.Wait ();
+            this.running = false;
+        }
+
+        internal class WatcherConfig : IConfigurationRoot, IConfigurationSection
+        {
+            Dictionary<string, string> rootValues;
+            Dictionary<string, WatcherConfig> sections = new Dictionary<string, WatcherConfig> ();
+
+            public WatcherConfig ()
+            {
+                this.rootValues = new Dictionary<string, string> ();
+            }
+
+            public WatcherConfig (Dictionary<string, string> values)
+            {
+                this.rootValues = values;
+            }
+
+            public string this[string key]
+            {
+                get => this.rootValues.ContainsKey(key) ? this.rootValues[key] : string.Empty;
+                set => this.rootValues[key] = value;
+            }
+
+            public void AddSection(string key, WatcherConfig value) => this.sections[key] = value;
+
+            public IConfigurationSection GetSection (string key) => this.sections.ContainsKey(key) ? this.sections[key] : null;
+
+            public IEnumerable<IConfigurationSection> GetChildren ()
+            {
+                return (new[] { this }).Union (this.sections.Values);
+            }
+
+            #region unused interface members
+
+            public IEnumerable<IConfigurationProvider> Providers => throw new NotImplementedException ();
+
+            string IConfigurationSection.Key => throw new NotImplementedException ();
+
+            string IConfigurationSection.Path => throw new NotImplementedException ();
+
+            string IConfigurationSection.Value { get => throw new NotImplementedException (); set => throw new NotImplementedException (); }
+
+
+            public IChangeToken GetReloadToken ()
+            {
+                throw new NotImplementedException ();
+            }
+
+            public void Reload ()
+            {
+                throw new NotImplementedException ();
+            }
+            #endregion
         }
 
         public class Startup

--- a/toolsrc/Chloroplast.Tool/Program.cs
+++ b/toolsrc/Chloroplast.Tool/Program.cs
@@ -22,7 +22,7 @@ namespace Chloroplast.Tool
             if (args.Length == 1 && args[0].EndsWith ("version", StringComparison.CurrentCultureIgnoreCase))
                 return;
 
-            if (args.Length < 1 || args.Length == 1 && args[0] == "build")
+            if (args.Length < 1 || args.Length == 1 && (args[0] == "build" || args[0] == "host"))
             {
                 string configPath = Directory.GetCurrentDirectory ().CombinePath ("SiteConfig.yml");
                 Console.WriteLine ($"looking for {configPath}");
@@ -30,7 +30,7 @@ namespace Chloroplast.Tool
                 {
                     args = new string[]
                     {
-                        "build",
+                        args.Length >= 1 ? args[0] : "build",
                         "--root",
                         Directory.GetCurrentDirectory(),
                         "--out",
@@ -126,7 +126,7 @@ namespace Chloroplast.Tool
             var builder = new ConfigurationBuilder ()
                 .AddCommandLine (subtaskargs);
 
-            if (subtask == "build")
+            if (subtask == "build" || subtask == "host")
             {
                 var sitePath = subtaskargs.Skip (1).First ().NormalizePath ();
                 if (!System.IO.Directory.Exists (sitePath))

--- a/toolsrc/Chloroplast.Tool/Program.cs
+++ b/toolsrc/Chloroplast.Tool/Program.cs
@@ -95,7 +95,7 @@ namespace Chloroplast.Tool
             catch (Exception ex)
             {
                 Console.Error.WriteLine ($"Oops, this was unexpected :(");
-                Console.Error.WriteLine (ex.Message);
+                Console.Error.WriteLine (ex.ToString());
                 if (ex.InnerException != null)
                 {
                     var currentEx = ex.InnerException;


### PR DESCRIPTION
This currently only supports watching markdown files in the areas ... so static file and razor template updates will not trigger a rebuild, nor will individual files configured in the `files` section of `SiteConfig.yml`