### PR TITLE
Instructions to host docs as a first step

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you want to see Chloroplast in action, you can even host the Chloroplast docs
 
 1. Install Chloroplast.
 
-    There are [several ways to install Chloroplast](https://github.com/WildernessLabs/Chloroplast/blob/main/docs/source/Installing/index.md#package-repository). This will isntall it from NuGet as a global tool.
+    There are [several ways to install Chloroplast](https://github.com/WildernessLabs/Chloroplast/blob/main/docs/source/Installing/index.md#package-repository). This will install it from NuGet as a global tool.
 
     ```
     dotnet tool install Chloroplast.Tool -g

--- a/README.md
+++ b/README.md
@@ -17,3 +17,37 @@ chloroplast host
 ```
 
 Once you're done with that, you can modify that default template, and [read the docs](/docs/).
+
+## Host the Chloroplast docs
+
+If you want to see Chloroplast in action, you can even host the Chloroplast docs themselves.
+
+1. Clone the Chloroplast repo.
+
+    ```
+    git clone https://github.com/WildernessLabs/Chloroplast.git
+    cd Chloroplast
+    ```
+
+1. Install Chloroplast.
+
+    There are [several ways to install Chloroplast](https://github.com/WildernessLabs/Chloroplast/blob/main/docs/source/Installing/index.md#package-repository). This will isntall it from NuGet as a global tool.
+
+    ```
+    dotnet tool install Chloroplast.Tool -g
+    ```
+
+1. Navigate to the Chloroplast docs.
+
+    ```
+    cd docs
+    ```
+
+1. Build and host the docs.
+
+    ```
+    chloroplast build
+    chloroplast host
+    ```
+
+    This will build and then start hosting the docs from `localhost:5000`, launching a browser to preview them.


### PR DESCRIPTION
Just a proposal...no pressure.

Since the Cholorplast docs are also built for Chloroplast, it felt like a cool first step for running it locally.