### PR TITLE
Add additional required SiteConfig.yml settings

### DIFF
--- a/docs/source/templates/index.md
+++ b/docs/source/templates/index.md
@@ -7,11 +7,15 @@ Chloroplast templates are built using asp.net's razor templates.
 
 # Configuration
 
-The `SiteConfig.yml` file lets you configure the location of templates.
+The `SiteConfig.yml` file lets you configure the location of templates and the folders to find content files to process.
 
-```
+```yaml
 # razor templates
-templates_folder: Templates
+templates_folder: templates
+
+areas:
+  - source_folder: /source
+    output_folder: /
 ```
 
 # Markdown front matter


### PR DESCRIPTION
I couldn't get any site output out of a `build` command until I added an `areas` YAML section to SiteConfig.yml. Figured it should be represented somewhere other than just the project docs site.

The template docs page didn't seem like the ideal location for this information, but it is a start. 