### PR TITLE
Some docs Markdown syntax tweaks

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -31,9 +31,9 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal toolsrc
     - name: Pack
-      run: dotnet pack toolsrc/Chloroplast.Core/   
+      run: dotnet pack toolsrc/Chloroplast.Core/
     - name: Pack Tool
-      run: dotnet pack toolsrc/Chloroplast.Tool/    
+      run: dotnet pack toolsrc/Chloroplast.Tool/
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2.1.3
       with:
@@ -59,4 +59,3 @@ jobs:
       run: dotnet nuget push ./toolsrc/Chloroplast.Tool/nupkg/*.nupkg --source "nuget.org" --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate --no-symbols true
       env:
         DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 0
-

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to see Chloroplast in action, you can even host the Chloroplast docs
     There are [several ways to install Chloroplast](https://github.com/WildernessLabs/Chloroplast/blob/main/docs/source/Installing/index.md#package-repository). This will install it from NuGet as a global tool.
 
     ```
-    dotnet tool install Chloroplast.Tool -g
+    dotnet tool install Chloroplast.Tool --global
     ```
 
 1. Navigate to the Chloroplast docs.

--- a/docs/source/Installing/index.md
+++ b/docs/source/Installing/index.md
@@ -3,57 +3,59 @@ template: Default
 title: Installing Chloroplast
 ---
 
-# Dependencies
+## Dependencies
 
 You must have the `dotnet` CLI installed ... to do so, you need only install _.NET Core_ on your machine. The instructions for that can be found here:
 
 https://docs.microsoft.com/en-us/dotnet/core/install/
 
-# Installing Chloroplast
+## Installing Chloroplast
 
 You can acquire Chloroplast by installing it as either a [local or global 
 tool](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install).
 
+### Wilderness Labs package registry
 
-## Wilderness Labs package registry
+#### Recommended
 
-### Recommended
 Chloroplast can be found on the public nuget.org package registry at:  
 https://www.nuget.org/packages/Chloroplast.Tool/
 
-### Package Repository
-However you can also choose to install it through the Wilderness Labs package
-registry. This means you'll need to add the authenticated NuGet source as follows if you wish to do so.
+#### Package Repository
 
-```
-dotnet nuget add source https://nuget.pkg.github.com/WildernessLabs/index.json --name “wildernesslabs” --username << your github username >> --password << a personal access token >>
+However, you can also choose to install it through the Wilderness Labs package registry. This means you'll need to add the authenticated NuGet source as follows if you wish to do so.
+
+```console
+dotnet nuget add source https://nuget.pkg.github.com/WildernessLabs/index.json --name "wildernesslabs" --username << your github username >> --password << a personal access token >>
 ```
 
-## Global
+### Global
+
 Regardless of which package registry you choose, you can install Chloroplast as a global tool.
 
-```
+```console
 dotnet tool install Chloroplast.Tool -g
 ```
 
 If you install it as a global tool, you can invoke it with the tool name
 `chloroplast`.
 
-## Local
+### Local
+
 Alternatively, you can install it as a local tool by first creating a local
 tool manifest in the project folder, as follows:
 
-```
+```console
 dotnet new tool-manifest
 dotnet tool install Chloroplast.Tool
 ```
 
 If you install it as a local tool, you must prefix the tool name, so you can invoke it with `dotnet chloroplast`.
 
-## Updating
+### Updating
 
 You can update to the latest release at any point by running the following command (with or without the `-g` depending on your preference):
 
-```
+```console
 dotnet tool update Chloroplast.Tool -g
 ```

--- a/docs/source/cli/index.md
+++ b/docs/source/cli/index.md
@@ -7,24 +7,21 @@ Chloroplast supports various sub commands. It is recommended to first `cd` into 
 
 ## `new` sub command
 
-The new subcommand allows you to bootstrap a chloroplast site by 
-copying files to a destination folder.
+The new subcommand allows you to bootstrap a chloroplast site by copying files to a destination folder.
 
-```
+```console
 chloroplast new conceptual targetFolder
 ```
 
-This will create `targetFolder` (if it doesn't already exist), and 
-copy files from the `conceptual` template. You can then run the
-following commands to build and preview the site locally:
+This will create `targetFolder`, if it doesn't already exist, and copy files from the `conceptual` template. You can then run the following commands to build and preview the site locally:
 
-```
+```console
 cd targetFolder
 chloroplast build
 chloroplast host
 ```
 
-### parameters
+### `new` parameters
 
 - `conceptual`: The second positional parameter after `new`.
   - This will currently only support `conceptual`, which will be a copy of these docs.
@@ -35,17 +32,17 @@ chloroplast host
 
 The build subcommand will build a Chloroplast site
 
-```
+```console
 chloroplast build --root path/to/SiteConfig/ --out path/to/out
 ```
 
-### parameters
+### `build` parameters
 
 - `root`: the path to the directory that contains a `SiteConfig.yml` file
 - `out`: the path to the directory where the resulting HTML will be output.
 - `normalizePaths`: defaults to `true`, which normalizes all paths to lower case. Set this to false for output paths to match the source casing.
 
-The parameters above will default to the current working directory for the root path, and an `out/` directory in that same path if both parameters are omitted. 
+The parameters above will default to the current working directory for the root path, and an `out/` directory in that same path if both parameters are omitted.
 
 The build command will render all `index.md` files into corresponding `index.html` files, and copy everything else to the same corresponding location (images, styles, etc).
 
@@ -53,15 +50,15 @@ The build command will render all `index.md` files into corresponding `index.htm
 
 The host sub command starts a simple HTML web server. Useful for local preview during development or even authoring. If you update markdown files, the content will automatically be rebuilt so you can just refresh the browser.
 
-```
-chloroplast host --root path/to/root --out path/to/html 
+```console
+chloroplast host --root path/to/root --out path/to/html
 ```
 
-You can just press the enter key to end this task after stopping the web host with Ctrl+C at any time. 
+You can just press the enter key to end this task after stopping the web host with Ctrl+C at any time.
 
 If you are updating razor templates, you can also just run this command in a separate terminal window and leave it running. That way, as you run the full `build` subcommand, the content and front-end styles will update, and you can just refresh the browser after that build has completed.
 
-### parameters
+### `host` parameters
 
 - `out`: This should be the same value as the `out` parameter used in the `build` command.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -4,7 +4,7 @@ title: Chloroplast Home
 subtitle: Documentation site for Chloroplast.
 ---
 
-# Welcome!
+## Welcome!
 
 To the Chloroplast docs. Once you [install it](/Installing), you can learn how to [use it](/cli), and [template it](/templates).
 

--- a/docs/source/templates/index.md
+++ b/docs/source/templates/index.md
@@ -53,15 +53,15 @@ For the main site's chrome, Chloroplast will look for a template named `SiteFram
 Available to all templates are the following functions:
 
 - `@Raw("<some string>")`
-  - the `Raw` method will avoid HTML encoding content (which is the default).
+  - The `Raw` method will avoid HTML encoding content (which is the default).
 - `@Model.Body`
-  - This is the main HTML content being rendered in this template. You should output this through the `Raw` method since it will likely contain HTML.
+  - This is the main HTML content being rendered using the page's template. You should output this through the `Raw` method since it will likely contain HTML.
 - `@Model.GetMeta("title")`
   - with this you can access any value in the front matter (for example, `title`).
 - `@await PartialAsync("TemplateName", "model value")`
   - This lets you render sub templates.
-  - the template name parameter will match the razor fil.e name ... so in the example above, it would be looking for a file named `Templates/TemplateName.cshtml`
-  - the second parameter can be any kind of object really, whatever the template in question is expecting.
+  - The template name parameter will match the Razor file name. So, in the example above, it would be looking for a file named `templates/TemplateName.cshtml`
+  - The second parameter can be any kind of object really, whatever the template in question is expecting.
 - `@Model.Headers` collection
   - Each `h1`-`h6` will be parsed and added to this headers collection.
   - Every `Header` object has the following properties:
@@ -69,5 +69,5 @@ Available to all templates are the following functions:
     - Value: the text
     - Slug: a slug version of the `Value`, which corresponds to an anchor added to the HTML before the header.
 - `@await PartialAsync("Docs/area/menu.md")`
-  - This overload of the `PartialAsync` method assumes you're rendering a markdown file.
-  - The markdown file can define its own template (will default to `Default`), and will only render the contents of that specific template (ie. no `SiteFrame.cshtml`).
+  - This overload of the `PartialAsync` method assumes you're rendering a Markdown file.
+  - The Markdown file can define its own template (default of `Default`), and will only render the contents of that specific template (ie. no `SiteFrame.cshtml`).

--- a/docs/source/templates/index.md
+++ b/docs/source/templates/index.md
@@ -5,7 +5,7 @@ title: Templating
 
 Chloroplast templates are built using ASP.NET's Razor templates.
 
-# Configuration
+## Configuration
 
 The `SiteConfig.yml` file lets you configure the location of templates and the folders to find content files to process.
 
@@ -18,11 +18,11 @@ areas:
     output_folder: /
 ```
 
-# Markdown front matter
+## Markdown front matter
 
-The template will be defined by the content's front matter. 
+The template will be defined by the content's front matter.
 
-```
+```console
 ---
 template: TemplateName
 title: Document title
@@ -31,11 +31,11 @@ title: Document title
 
 If this value is either incorrect, or omitted, it will default to look for a template named `Default.cshtml`. These templates are assumed to be just for the content area itself.
 
-# SiteFrame.cshtml
+## SiteFrame.cshtml
 
 For the main site's chrome, Chloroplast will look for a template named `SiteFrame.cshtml` ... this will render
 
-```
+```console
 <html>
 <head>
     <title>@Model.GetMeta("Title")</title>
@@ -48,7 +48,7 @@ For the main site's chrome, Chloroplast will look for a template named `SiteFram
 </html>
 ```
 
-# Template Properties and Methods
+## Template Properties and Methods
 
 Available to all templates are the following functions:
 
@@ -59,7 +59,7 @@ Available to all templates are the following functions:
 - `@Model.GetMeta("title")`
   - with this you can access any value in the front matter (for example, `title`).
 - `@await PartialAsync("TemplateName", "model value")`
-  - This lets you render sub templates. 
+  - This lets you render sub templates.
   - the template name parameter will match the razor fil.e name ... so in the example above, it would be looking for a file named `Templates/TemplateName.cshtml`
   - the second parameter can be any kind of object really, whatever the template in question is expecting.
 - `@Model.Headers` collection

--- a/toolsrc/Chloroplast.Core/Rendering/YamlRenderer.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/YamlRenderer.cs
@@ -74,7 +74,7 @@ namespace Chloroplast.Core.Rendering
         public static void RenderAndSaveMenu(string filePath, IEnumerable<MenuNode> nodes)
         {
             var serializer = new SerializerBuilder ()
-                .WithNamingConvention(new YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention())
+                .WithNamingConvention(YamlDotNet.Serialization.NamingConventions.CamelCaseNamingConvention.Instance)
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
                 .Build();
             string fileContent = serializer.Serialize (new

--- a/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
+++ b/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
@@ -9,7 +9,7 @@
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
 
-    <Version>0.5.4</Version>
+    <Version>0.5.5-alpha1</Version>
     <Authors>Wilderness Labs</Authors>
     <Company>Wilderness Labs</Company>
     <PackageDescription>Markdown-based static site generator</PackageDescription>


### PR DESCRIPTION
- [x] Bumped headers a number because the [site wrapper had an H1 already](https://github.com/WildernessLabs/Chloroplast/blob/main/docs/templates/SiteFrame.cshtml#L32).
- [x] Add some missing code fence languages.
- [x] Some random capitalization fixes and removed some trailing whitespace.