### PR TITLE
use correct framework

### DIFF
--- a/toolsrc/Chloroplast.Core/Chloroplast.Core.csproj
+++ b/toolsrc/Chloroplast.Core/Chloroplast.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>

--- a/toolsrc/Chloroplast.Test/Chloroplast.Test.csproj
+++ b/toolsrc/Chloroplast.Test/Chloroplast.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
+++ b/toolsrc/Chloroplast.Tool/Chloroplast.Tool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>chloroplast</ToolCommandName>

--- a/toolsrc/Chloroplast.Web/Chloroplast.Web.csproj
+++ b/toolsrc/Chloroplast.Web/Chloroplast.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)