### PR TITLE
Restore RazorLight with MiniRazor backcompat and failing builds

### DIFF
--- a/docs/source/templates/index.es.md
+++ b/docs/source/templates/index.es.md
@@ -6,6 +6,16 @@ machineTranslated: true
 
 Las plantillas de Chloroplast están construidas usando las plantillas Razor de ASP.NET.
 
+## Guía de Autoría
+
+Las plantillas nuevas deben usar **sintaxis estándar de Razor / RazorLight**.
+
+- Prefiere construcciones normales de Razor como `@functions`, `@if`, `@foreach` y métodos helper que devuelvan cadenas o `RawString`.
+- Importa tipos de Chloroplast desde `Chloroplast.Core.Rendering` cuando los necesites.
+- Usa `@Raw(...)` cuando realmente quieras escribir HTML sin codificar.
+
+Las plantillas heredadas que todavía incluyen `@using MiniRazor` siguen siendo compatibles por retrocompatibilidad, especialmente para usos antiguos de `RawString`. Sin embargo, las plantillas nuevas deben evitar patrones específicos de MiniRazor y escribirse como plantillas nativas de RazorLight.
+
 # Configuración
 
 El archivo `SiteConfig.yml` te permite configurar la ubicación de las plantillas y las carpetas para encontrar archivos de contenido para procesar.
@@ -72,8 +82,9 @@ Si no se encuentra una plantilla de marco especificada:
 - El archivo de contenido afectado se omite (no se renderiza una página incompleta)
 - La compilación continúa procesando otros archivos
 - El error se incluye en el resumen de errores de compilación
+- El comando `chloroplast build` termina con un código distinto de cero al final
 
-Esto asegura que el proceso de compilación no se detenga completamente debido a un marco faltante, pero serás notificado del problema.
+Los errores de compilación o renderizado de plantillas también se incluyen en el resumen de errores y ahora hacen fallar el comando de compilación. Esto mantiene la compatibilidad hacia atrás para el contenido existente, pero evita que se publiquen salidas rotas de plantillas en silencio.
 
 # Personalizando Plantillas
 

--- a/docs/source/templates/index.md
+++ b/docs/source/templates/index.md
@@ -5,6 +5,16 @@ title: Templating
 
 Chloroplast templates are built using ASP.NET's Razor templates.
 
+## Authoring Guidance
+
+New templates should use **standard Razor / RazorLight syntax**.
+
+- Prefer normal Razor constructs such as `@functions`, `@if`, `@foreach`, and helper methods that return strings or `RawString`.
+- Import Chloroplast types from `Chloroplast.Core.Rendering` when you need them.
+- Use `@Raw(...)` when you intentionally want to write HTML without encoding.
+
+Legacy templates that still include `@using MiniRazor` remain supported for backward compatibility, especially for older `RawString` usage. However, new templates should avoid MiniRazor-specific patterns and be written as native RazorLight templates.
+
 # Configuration
 
 The `SiteConfig.yml` file lets you configure the location of templates and the folders to find content files to process.
@@ -71,8 +81,9 @@ If a specified frame template is not found:
 - The affected content file is skipped (no incomplete page is rendered)
 - The build continues processing other files
 - The error is included in the build error summary
+- The overall `chloroplast build` command exits non-zero at the end
 
-This ensures the build process doesn't stop completely due to a missing frame, but you'll be notified of the issue.
+Template compilation/rendering failures are also reported in the build error summary and now cause the build command to fail. This keeps site generation backward compatible for existing content while preventing broken template output from silently shipping.
 
 # Customizing Templates
 

--- a/docs/templates/menu.cshtml
+++ b/docs/templates/menu.cshtml
@@ -1,32 +1,63 @@
 @inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.RenderedContent>
 @using Chloroplast.Core
-@using System.Linq;
-@using System.Collections.Generic;
-@using Microsoft.Extensions.Configuration;
-@using Chloroplast.Core.Extensions;
-@using MiniRazor;
-@{
-    RawString RenderNodes(IConfigurationSection section)
+@using Chloroplast.Core.Extensions
+@using Chloroplast.Core.Rendering
+@using Microsoft.Extensions.Configuration
+@using System.Collections.Generic
+@using System.Linq
+@using System.Net
+@using System.Text
+@functions {
+    private RawString RenderNodes(IConfigurationSection section)
     {
-        var children = section.GetChildren();
-        if (children.Any())
+        if (section == null)
         {
-        <ul class="nav">
-            @foreach(var item in children)
-            {
-                var localizedPath = BuildMenuItemHref(item["path"]);
-                if (string.IsNullOrEmpty(localizedPath)) { continue; }
-                <li class="nav-item">
-                    <a href="@localizedPath" class="nav-link">@item["title"]</a>
-                    @if (item.ContainsKey("items"))
-                    {
-                        @RenderNodes(item.GetSection("items"))
-                    }
-                </li>
-            }
-        </ul>
+            return new RawString(string.Empty);
         }
-        return new RawString("");
+
+        var children = section.GetChildren().ToArray();
+        if (children.Length == 0)
+        {
+            return new RawString(string.Empty);
+        }
+
+        var builder = new StringBuilder();
+        AppendNodes(builder, children);
+        return new RawString(builder.ToString());
+    }
+
+    private void AppendNodes(StringBuilder builder, IEnumerable<IConfigurationSection> nodes)
+    {
+        builder.Append("<ul class=\"nav\">");
+
+        foreach (var item in nodes)
+        {
+            var localizedPath = BuildMenuItemHref(item["path"]);
+            if (string.IsNullOrEmpty(localizedPath))
+            {
+                continue;
+            }
+
+            builder.Append("<li class=\"nav-item\">");
+            builder.Append("<a href=\"");
+            builder.Append(WebUtility.HtmlEncode(localizedPath));
+            builder.Append("\" class=\"nav-link\">");
+            builder.Append(WebUtility.HtmlEncode(item["title"]));
+            builder.Append("</a>");
+
+            if (item.ContainsKey("items"))
+            {
+                var childItems = item.GetSection("items").GetChildren().ToArray();
+                if (childItems.Length > 0)
+                {
+                    AppendNodes(builder, childItems);
+                }
+            }
+
+            builder.Append("</li>");
+        }
+
+        builder.Append("</ul>");
     }
 }
 

--- a/toolsrc/Chloroplast.Core/Chloroplast.Core.csproj
+++ b/toolsrc/Chloroplast.Core/Chloroplast.Core.csproj
@@ -5,6 +5,7 @@
     
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <IsPackable>true</IsPackable>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
 
   <Version Condition="'$(Version)' == ''">0.13.0</Version>
     <Authors>Wilderness Labs</Authors>
@@ -20,8 +21,9 @@
     <PackageReference Include="Markdig" Version="0.41.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.0.6" />
-    <PackageReference Include="MiniRazor" Version="2.2.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="RazorLight" Version="2.3.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.6" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Content\" />

--- a/toolsrc/Chloroplast.Core/Rendering/ChloroplastTemplateBase.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/ChloroplastTemplateBase.cs
@@ -2,14 +2,32 @@
 using System.Threading.Tasks;
 using Chloroplast.Core.Content;
 using Chloroplast.Core.Extensions;
-using MiniRazor;
+using RazorLight;
 
 namespace Chloroplast.Core.Rendering
 {
-    public abstract class ChloroplastTemplateBase<T> : TemplateBase<T> where T : RenderedContent
+    public abstract class ChloroplastTemplateBase<T> : TemplatePage<T> where T : RenderedContent
     {
         public ChloroplastTemplateBase ()
         {
+        }
+
+        /// <summary>
+        /// Returns a <see cref="RawString"/> that is written to the output without HTML encoding.
+        /// Use in templates as <c>@Raw(someHtmlString)</c>.
+        /// </summary>
+        protected new RawString Raw (string value) => new RawString (value);
+
+        /// <summary>
+        /// Overrides the base Write method to emit <see cref="RawString"/> values without encoding.
+        /// All other values are HTML-encoded by the base implementation.
+        /// </summary>
+        public new void Write (object value)
+        {
+            if (value is RawString raw)
+                WriteLiteral (raw.ToString ());
+            else
+                base.Write (value);
         }
 
         /// <summary>

--- a/toolsrc/Chloroplast.Core/Rendering/MiniRazorCompat.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/MiniRazorCompat.cs
@@ -1,0 +1,13 @@
+namespace MiniRazor
+{
+    /// <summary>
+    /// Backward-compatible shim so legacy templates that import MiniRazor can
+    /// continue to use RawString with the RazorLight-based renderer.
+    /// </summary>
+    public class RawString : Chloroplast.Core.Rendering.RawString
+    {
+        public RawString (string value) : base (value)
+        {
+        }
+    }
+}

--- a/toolsrc/Chloroplast.Core/Rendering/RawString.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/RawString.cs
@@ -1,0 +1,17 @@
+namespace Chloroplast.Core.Rendering
+{
+    /// <summary>
+    /// Represents a string that should be written to a template output without HTML encoding.
+    /// </summary>
+    public class RawString
+    {
+        private readonly string _value;
+
+        public RawString (string value)
+        {
+            _value = value ?? string.Empty;
+        }
+
+        public override string ToString () => _value;
+    }
+}

--- a/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Chloroplast.Core.Extensions;
-//using Choroplast.Core.Loaders.EcmaXml;
 using Microsoft.Extensions.Configuration;
-using MiniRazor;
+using RazorLight;
 
 namespace Chloroplast.Core.Rendering
 {
@@ -13,9 +12,9 @@ namespace Chloroplast.Core.Rendering
     {
         public static RazorRenderer Instance;
 
-        Dictionary<string, TemplateDescriptor> templates = new Dictionary<string, TemplateDescriptor> ();
+        IRazorLightEngine engine;
+        Dictionary<string, string> templateSources = new Dictionary<string, string> ();
         string templatesFolderPath;
-        //TemplateEngine engine = new TemplateEngine ();
 
         public async Task AddTemplateAsync (string templatePath, string templatesFolderPath)
         {
@@ -27,21 +26,19 @@ namespace Chloroplast.Core.Rendering
             string relativeKey = relativePath.Replace('\\', '/').Replace(".cshtml", "");
             
             // Store with both the relative path and the filename for backward compatibility
-            var compiledTemplate = Razor.Compile (await File.ReadAllTextAsync (templatePath));
+            string source = await File.ReadAllTextAsync (templatePath);
             
             // Store by relative path (e.g., "template/topNav")
-            if (!templates.ContainsKey (relativeKey))
+            if (!templateSources.ContainsKey (relativeKey))
             {
-                Chloroplast.Core.Loaders.EcmaXml.Namespace ns = new Chloroplast.Core.Loaders.EcmaXml.Namespace ();
-                Console.WriteLine (ns.ToString ());
-                templates[relativeKey] = compiledTemplate;
+                templateSources[relativeKey] = source;
             }
             
             // Also store by filename only for backward compatibility (e.g., "topNav")
             // But only if there's no conflict
-            if (!templates.ContainsKey (fileName))
+            if (!templateSources.ContainsKey (fileName))
             {
-                templates[fileName] = compiledTemplate;
+                templateSources[fileName] = source;
             }
         }
 
@@ -56,6 +53,11 @@ namespace Chloroplast.Core.Rendering
             templatesFolderPath = rootPath
                 .CombinePath(templateFolderSetting)
                 .NormalizePath();
+
+            engine = new RazorLightEngineBuilder ()
+                .UseMemoryCachingProvider ()
+                .SetOperatingAssembly (typeof (RazorRenderer).Assembly)
+                .Build ();
 
             foreach (var razorPath in Directory.EnumerateFiles (templatesFolderPath, "*.cshtml", SearchOption.AllDirectories))
             {
@@ -79,9 +81,9 @@ namespace Chloroplast.Core.Rendering
                 }
 
                 // Try to find the frame template
-                var frame = FindTemplate(frameName);
+                string key = FindKey(frameName);
                 
-                if (frame == null)
+                if (key == null)
                 {
                     // Log error and return null to signal the file should be skipped
                     Console.ForegroundColor = ConsoleColor.Red;
@@ -90,7 +92,7 @@ namespace Chloroplast.Core.Rendering
                     return null;
                 }
 
-                var result = await frame.RenderAsync (parsed);
+                var result = await engine.CompileRenderStringAsync<FrameRenderedContent> (key, templateSources[key], parsed);
                 return result;
             }
             catch (Exception ex)
@@ -104,8 +106,8 @@ namespace Chloroplast.Core.Rendering
 
         public async Task<RawString> RenderTemplateContent<T> (string templateName, T model)
         {
-            var template = FindTemplate(templateName);
-            if (template == null)
+            string key = FindKey(templateName);
+            if (key == null)
             {
                 // Template not found - log warning and return empty string instead of throwing
                 Console.ForegroundColor = ConsoleColor.Yellow;
@@ -113,31 +115,32 @@ namespace Chloroplast.Core.Rendering
                 Console.ResetColor();
                 return new RawString(string.Empty);
             }
-            return new RawString (await template.RenderAsync (model));
+            return new RawString (await engine.CompileRenderStringAsync<T> (key, templateSources[key], model));
         }
 
         public bool TemplateExists(string templateName)
         {
-            return FindTemplate(templateName) != null;
+            return FindKey(templateName) != null;
         }
 
-        private TemplateDescriptor FindTemplate(string templateName)
+        private string FindKey(string templateName)
         {
             // Try multiple lookup strategies to find the template
             
             // 1. Try exact match (could be relative path like "template/topNav")
-            if (templates.TryGetValue(templateName, out var template))
+            if (templateSources.ContainsKey(templateName))
             {
-                return template;
+                return templateName;
             }
 
             // 2. Try with .cshtml extension if not already present
             if (!templateName.EndsWith(".cshtml"))
             {
                 string withExtension = templateName + ".cshtml";
-                if (templates.TryGetValue(withExtension.Replace('\\', '/').Replace(".cshtml", ""), out template))
+                string normalized = withExtension.Replace('\\', '/').Replace(".cshtml", "");
+                if (templateSources.ContainsKey(normalized))
                 {
-                    return template;
+                    return normalized;
                 }
             }
 
@@ -145,17 +148,18 @@ namespace Chloroplast.Core.Rendering
             if (templateName.EndsWith(".cshtml"))
             {
                 string withoutExtension = templateName.Substring(0, templateName.Length - 7);
-                if (templates.TryGetValue(withoutExtension.Replace('\\', '/'), out template))
+                string normalized = withoutExtension.Replace('\\', '/');
+                if (templateSources.ContainsKey(normalized))
                 {
-                    return template;
+                    return normalized;
                 }
             }
 
             // 4. Normalize path separators and try again
             string normalizedName = templateName.Replace('\\', '/');
-            if (templates.TryGetValue(normalizedName, out template))
+            if (templateSources.ContainsKey(normalizedName))
             {
-                return template;
+                return normalizedName;
             }
 
             // 5. Last resort: if path starts with "templates/", strip it and try all lookups again
@@ -163,7 +167,7 @@ namespace Chloroplast.Core.Rendering
             if (normalizedName.StartsWith("templates/", StringComparison.OrdinalIgnoreCase))
             {
                 string withoutTemplatesPrefix = normalizedName.Substring("templates/".Length);
-                return FindTemplate(withoutTemplatesPrefix); // Recursive call with stripped path
+                return FindKey(withoutTemplatesPrefix); // Recursive call with stripped path
             }
 
             return null;
@@ -182,13 +186,13 @@ namespace Chloroplast.Core.Rendering
                 if (parsed.Metadata.ContainsKey ("layout"))
                     templateName = parsed.Metadata["layout"];
 
-                TemplateDescriptor template = FindTemplate(templateName);
+                string key = FindKey(templateName);
 
-                if (template == null)
-                    template = FindTemplate(defaultTemplateName);
+                if (key == null)
+                    key = FindKey(defaultTemplateName);
 
                 // Render template
-                var result = await template.RenderAsync (parsed);
+                var result = await engine.CompileRenderStringAsync<RenderedContent> (key, templateSources[key], parsed);
 
                 return result;
 
@@ -208,13 +212,10 @@ namespace Chloroplast.Core.Rendering
             {
                 string templateName = "Namespace";
 
-                TemplateDescriptor template;
-
-                if (!templates.TryGetValue (templateName, out template))
-                    template = templates[templateName];
+                string key = FindKey(templateName) ?? templateName;
 
                 // Render template
-                var result = await template.RenderAsync (parsed);
+                var result = await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.Namespace>> (key, templateSources[key], parsed);
 
                 return result;
 
@@ -234,13 +235,10 @@ namespace Chloroplast.Core.Rendering
             {
                 string templateName = "Type";
 
-                TemplateDescriptor template;
-
-                if (!templates.TryGetValue (templateName, out template))
-                    template = templates[templateName];
+                string key = FindKey(templateName) ?? templateName;
 
                 // Render template
-                var result = await template.RenderAsync (parsed);
+                var result = await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.XType>> (key, templateSources[key], parsed);
 
                 return result;
 

--- a/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
+++ b/toolsrc/Chloroplast.Core/Rendering/RazorRenderer.cs
@@ -71,37 +71,23 @@ namespace Chloroplast.Core.Rendering
 
         public async Task<string> RenderContentAsync (FrameRenderedContent parsed)
         {
-            try
+            // Check for custom frame in metadata, default to "SiteFrame"
+            string frameName = parsed.Metadata?["frame"] ?? "SiteFrame";
+            if (string.IsNullOrEmpty(frameName))
             {
-                // Check for custom frame in metadata, default to "SiteFrame"
-                string frameName = parsed.Metadata?["frame"] ?? "SiteFrame";
-                if (string.IsNullOrEmpty(frameName))
-                {
-                    frameName = "SiteFrame";
-                }
-
-                // Try to find the frame template
-                string key = FindKey(frameName);
-                
-                if (key == null)
-                {
-                    // Log error and return null to signal the file should be skipped
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    Console.WriteLine($"ERROR: Frame template '{frameName}' not found for content '{parsed.Node?.Title ?? "unknown"}'. Skipping this file.");
-                    Console.ResetColor();
-                    return null;
-                }
-
-                var result = await engine.CompileRenderStringAsync<FrameRenderedContent> (key, templateSources[key], parsed);
-                return result;
+                frameName = "SiteFrame";
             }
-            catch (Exception ex)
+
+            string key = FindKey(frameName);
+            if (key == null)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine (ex.ToString ());
-                Console.ResetColor ();
-                return ex.ToString ();
+                Console.WriteLine($"ERROR: Frame template '{frameName}' not found for content '{parsed.Node?.Title ?? "unknown"}'. Skipping this file.");
+                Console.ResetColor();
+                return null;
             }
+
+            return await engine.CompileRenderStringAsync<FrameRenderedContent> (key, templateSources[key], parsed);
         }
 
         public async Task<RawString> RenderTemplateContent<T> (string templateName, T model)
@@ -175,81 +161,51 @@ namespace Chloroplast.Core.Rendering
 
         public async Task<string> RenderContentAsync (RenderedContent parsed)
         {
-            try
+            string defaultTemplateName = "Default";
+            string templateName = defaultTemplateName;
+
+            if (parsed.Metadata.ContainsKey ("template"))
+                templateName = parsed.Metadata["template"];
+
+            if (parsed.Metadata.ContainsKey ("layout"))
+                templateName = parsed.Metadata["layout"];
+
+            string key = FindKey(templateName);
+
+            if (key == null)
+                key = FindKey(defaultTemplateName);
+
+            if (key == null)
             {
-                string defaultTemplateName = "Default";
-                string templateName = defaultTemplateName;
-
-                if (parsed.Metadata.ContainsKey ("template"))
-                    templateName = parsed.Metadata["template"];
-
-                if (parsed.Metadata.ContainsKey ("layout"))
-                    templateName = parsed.Metadata["layout"];
-
-                string key = FindKey(templateName);
-
-                if (key == null)
-                    key = FindKey(defaultTemplateName);
-
-                // Render template
-                var result = await engine.CompileRenderStringAsync<RenderedContent> (key, templateSources[key], parsed);
-
-                return result;
-
+                throw new ApplicationException (
+                    $"Template '{templateName}' could not be resolved and default template '{defaultTemplateName}' was not found.");
             }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine (ex.ToString ());
-                Console.ResetColor ();
-                return ex.ToString ();
-            }
+
+            return await engine.CompileRenderStringAsync<RenderedContent> (key, templateSources[key], parsed);
         }
 
         public async Task<string> RenderContentAsync (EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.Namespace> parsed)
         {
-            try
+            string templateName = "Namespace";
+            string key = FindKey(templateName);
+            if (key == null)
             {
-                string templateName = "Namespace";
-
-                string key = FindKey(templateName) ?? templateName;
-
-                // Render template
-                var result = await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.Namespace>> (key, templateSources[key], parsed);
-
-                return result;
-
+                throw new ApplicationException ($"Template '{templateName}' was not found.");
             }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine (ex.ToString ());
-                Console.ResetColor ();
-                return ex.ToString ();
-            }
+
+            return await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.Namespace>> (key, templateSources[key], parsed);
         }
 
         public async Task<string> RenderContentAsync (EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.XType> parsed)
         {
-            try
+            string templateName = "Type";
+            string key = FindKey(templateName);
+            if (key == null)
             {
-                string templateName = "Type";
-
-                string key = FindKey(templateName) ?? templateName;
-
-                // Render template
-                var result = await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.XType>> (key, templateSources[key], parsed);
-
-                return result;
-
+                throw new ApplicationException ($"Template '{templateName}' was not found.");
             }
-            catch (Exception ex)
-            {
-                Console.ForegroundColor = ConsoleColor.Red;
-                Console.WriteLine (ex.ToString ());
-                Console.ResetColor ();
-                return ex.ToString ();
-            }
+
+            return await engine.CompileRenderStringAsync<EcmaXmlContent<Chloroplast.Core.Loaders.EcmaXml.XType>> (key, templateSources[key], parsed);
         }
     }
 }

--- a/toolsrc/Chloroplast.Test/BuildCommandTests.cs
+++ b/toolsrc/Chloroplast.Test/BuildCommandTests.cs
@@ -132,5 +132,118 @@ namespace Chloroplast.Test
             var exception = Record.Exception(() => method.Invoke(buildCommand, new object[] { config }));
             Assert.Null(exception);
         }
+
+        [Fact]
+        public async Task BuildCommand_ShouldWriteRenderedHtmlFiles()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var sourceDir = Path.Combine(tempDir, "source");
+            var templatesDir = Path.Combine(tempDir, "templates");
+            var outputDir = Path.Combine(tempDir, "out");
+
+            Directory.CreateDirectory(sourceDir);
+            Directory.CreateDirectory(templatesDir);
+            Directory.CreateDirectory(outputDir);
+
+            try
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(sourceDir, "index.md"),
+                    "---\ntitle: Home\n---\n# Hello");
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(templatesDir, "Default.cshtml"),
+                    "@inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.RenderedContent>\n@Raw(Model.Body)");
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(templatesDir, "SiteFrame.cshtml"),
+                    "@inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.FrameRenderedContent>\n<!DOCTYPE html><html><body>@Raw(Model.Body)</body></html>");
+
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { "root", tempDir },
+                        { "out", outputDir },
+                        { "templates_folder", "templates" },
+                        { "defaultLocale", "en" },
+                        { "supportedLocales:0", "en" },
+                        { "areas:0:source_folder", "/source" },
+                        { "areas:0:output_folder", "/" }
+                    })
+                    .Build();
+
+                SiteConfig.Instance = config;
+
+                var buildCommand = new FullBuildCommand();
+                await buildCommand.RunAsync(config);
+
+                var outputFile = Path.Combine(outputDir, "index.html");
+                Assert.True(File.Exists(outputFile));
+                Assert.Contains("<h1>Hello</h1>", await File.ReadAllTextAsync(outputFile));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task BuildCommand_ShouldFailWhenTemplateRenderingFails()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var sourceDir = Path.Combine(tempDir, "source");
+            var templatesDir = Path.Combine(tempDir, "templates");
+            var outputDir = Path.Combine(tempDir, "out");
+
+            Directory.CreateDirectory(sourceDir);
+            Directory.CreateDirectory(templatesDir);
+            Directory.CreateDirectory(outputDir);
+
+            try
+            {
+                await File.WriteAllTextAsync(
+                    Path.Combine(sourceDir, "index.md"),
+                    "---\ntitle: Home\n---\n# Hello");
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(templatesDir, "Default.cshtml"),
+                    "@using Missing.Template.Namespace\n@inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.RenderedContent>\n@Raw(Model.Body)");
+
+                await File.WriteAllTextAsync(
+                    Path.Combine(templatesDir, "SiteFrame.cshtml"),
+                    "@inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.FrameRenderedContent>\n<!DOCTYPE html><html><body>@Raw(Model.Body)</body></html>");
+
+                var config = new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>
+                    {
+                        { "root", tempDir },
+                        { "out", outputDir },
+                        { "templates_folder", "templates" },
+                        { "defaultLocale", "en" },
+                        { "supportedLocales:0", "en" },
+                        { "areas:0:source_folder", "/source" },
+                        { "areas:0:output_folder", "/" }
+                    })
+                    .Build();
+
+                SiteConfig.Instance = config;
+
+                var buildCommand = new FullBuildCommand();
+                var exception = await Assert.ThrowsAsync<ChloroplastException>(() => buildCommand.RunAsync(config));
+
+                Assert.Contains("Build failed", exception.Message);
+                Assert.False(File.Exists(Path.Combine(outputDir, "index.html")));
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+            }
+        }
     }
 }

--- a/toolsrc/Chloroplast.Test/RazorTests.cs
+++ b/toolsrc/Chloroplast.Test/RazorTests.cs
@@ -295,6 +295,57 @@ namespace Chloroplast.Test
             }
         }
 
+        [Fact]
+        public async Task LegacyMiniRazorUsing_AllowsRawStringRendering()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var templatesDir = Path.Combine(tempDir, "templates");
+
+            Directory.CreateDirectory(templatesDir);
+
+            var templateContent =
+                "@using MiniRazor;\n" +
+                "@inherits Chloroplast.Core.Rendering.ChloroplastTemplateBase<Chloroplast.Core.Rendering.RenderedContent>\n" +
+                "@{ var html = new RawString(\"<strong>\" + Model.Body + \"</strong>\"); }\n" +
+                "@html";
+            var templatePath = Path.Combine(templatesDir, "LegacyTemplate.cshtml");
+            await File.WriteAllTextAsync(templatePath, templateContent);
+
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    { "root", tempDir },
+                    { "templates_folder", "templates" }
+                })
+                .Build();
+
+            var renderer = new RazorRenderer();
+
+            try
+            {
+                var originalOut = Console.Out;
+                using var stringWriter = new StringWriter();
+                Console.SetOut(stringWriter);
+
+                await renderer.InitializeAsync(config);
+
+                var model = new RenderedContent { Body = "Hello" };
+                var result = await renderer.RenderTemplateContent("LegacyTemplate", model);
+
+                Console.SetOut(originalOut);
+
+                Assert.Contains("<strong>Hello</strong>", result.ToString());
+                Assert.DoesNotContain("&lt;strong&gt;", result.ToString());
+            }
+            finally
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
         //[Fact]
         public async Task SimpleRender()
         {

--- a/toolsrc/Chloroplast.Test/RazorTests.cs
+++ b/toolsrc/Chloroplast.Test/RazorTests.cs
@@ -46,7 +46,7 @@ namespace Chloroplast.Test
             Directory.CreateDirectory(subDir);
             
             // Create a template in subdirectory
-            var templateContent = "@inherits MiniRazor.TemplateBase<string>\n@Model";
+            var templateContent = "@inherits RazorLight.TemplatePage<string>\n@Model";
             var templatePath = Path.Combine(subDir, "TestTemplate.cshtml");
             await File.WriteAllTextAsync(templatePath, templateContent);
             
@@ -99,7 +99,7 @@ namespace Chloroplast.Test
             Directory.CreateDirectory(templatesDir);
             
             // Create a template at root level
-            var templateContent = "@inherits MiniRazor.TemplateBase<string>\nRoot: @Model";
+            var templateContent = "@inherits RazorLight.TemplatePage<string>\nRoot: @Model";
             var templatePath = Path.Combine(templatesDir, "MyTemplate.cshtml");
             await File.WriteAllTextAsync(templatePath, templateContent);
             
@@ -152,7 +152,7 @@ namespace Chloroplast.Test
             
             Directory.CreateDirectory(subDir);
             
-            var templateContent = "@inherits MiniRazor.TemplateBase<string>\nPartial: @Model";
+            var templateContent = "@inherits RazorLight.TemplatePage<string>\nPartial: @Model";
             var templatePath = Path.Combine(subDir, "Header.cshtml");
             await File.WriteAllTextAsync(templatePath, templateContent);
             
@@ -204,7 +204,7 @@ namespace Chloroplast.Test
             
             Directory.CreateDirectory(subDir);
             
-            var templateContent = "@inherits MiniRazor.TemplateBase<string>\nComponent: @Model";
+            var templateContent = "@inherits RazorLight.TemplatePage<string>\nComponent: @Model";
             var templatePath = Path.Combine(subDir, "Nav.cshtml");
             await File.WriteAllTextAsync(templatePath, templateContent);
             
@@ -256,7 +256,7 @@ namespace Chloroplast.Test
             
             Directory.CreateDirectory(templatesDir);
             
-            var templateContent = "@inherits MiniRazor.TemplateBase<string>\nTemplate: @Model";
+            var templateContent = "@inherits RazorLight.TemplatePage<string>\nTemplate: @Model";
             var templatePath = Path.Combine(templatesDir, "MyTemplate.cshtml");
             await File.WriteAllTextAsync(templatePath, templateContent);
             

--- a/toolsrc/Chloroplast.Tool/Commands/FullBuildCommand.cs
+++ b/toolsrc/Chloroplast.Tool/Commands/FullBuildCommand.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Threading.Tasks.Dataflow;
 
 using Chloroplast.Core;
 using Chloroplast.Core.Content;
@@ -57,18 +56,18 @@ namespace Chloroplast.Tool.Commands
                         Console.Error.WriteLine($"Failed to write error log: {logEx.Message}");
                     }
                 }
-                
-                return new Task[0];
+
+                throw new ChloroplastException ("Failed to initialize content renderer.", ex);
             }
 
-            List<Task<Task<RenderedContent>>> tasks= new List<Task<Task<RenderedContent>>>();
+            List<Task<RenderedContent>> tasks = new List<Task<RenderedContent>> ();
 
             // Start iterating over content
             foreach (var area in ContentArea.LoadContentAreas (config))
             {
                 Console.WriteLine ($"Processing area: {area.SourcePath}");
 
-                List<Task<Task<RenderedContent>>> firsttasks = new List<Task<Task<RenderedContent>>> ();
+                List<Task<RenderedContent>> firsttasks = new List<Task<RenderedContent>> ();
                 foreach (var item in area.ContentNodes)
                 {
                     if (config["force"] == string.Empty &&
@@ -77,47 +76,10 @@ namespace Chloroplast.Tool.Commands
                         continue;
                     }
 
-                    // TODO: refactor this out to a build queue
-                    firsttasks.Add(Task.Factory.StartNew(async () =>
-                    {
-                        try
-                        {
-                            Console.WriteLine ($"\tdoc: {item.Source.RootRelativePath}");
-
-                            if (item.Source.RootRelativePath.EndsWith(".md"))
-                            {
-                                var r = await ContentRenderer.FromMarkdownAsync(item);
-                                r = await ContentRenderer.ToRazorAsync(r);
-                                //await item.Target.WriteContentAsync(r.Body);
-
-                                return r;
-                            }
-                            else if (item.Source.RootRelativePath.EndsWith(".xml"))
-                            {
-                                var r = await ContentRenderer.FromEcmaXmlAsync (item, config);
-                                //r = await ContentRenderer.ToRazorAsync (r);
-
-                                return r;
-                            }
-                            else
-                            {
-                                item.Source.CopyTo(item.Target);
-                                return null;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            _buildErrors.AddError(item.Source.RootRelativePath, 
-                                $"Failed to process content file", ex);
-                            Console.WriteLine($"\tERROR processing: {item.Source.RootRelativePath}");
-                            return null;
-                        }
-                    }));
+                    firsttasks.Add (ProcessContentItemAsync (item, config));
                 }
 
-                Task.WaitAll (firsttasks.ToArray ());
-                var rendered = firsttasks
-                    .Select (t => t.Result.Result)
+                var rendered = (await Task.WhenAll (firsttasks))
                     .Where(r => r != null);
 
                 IEnumerable<ContentNode> menutree;
@@ -183,39 +145,10 @@ namespace Chloroplast.Tool.Commands
 
                 foreach (var item in rendered.Select(r => new FrameRenderedContent(r, menutree)))
                 {
-                    tasks.Add (Task.Factory.StartNew (async () =>
-                    {
-                        try
-                        {
-                            Console.WriteLine ($"\tframe rendering: {item.Node.Title}");
-
-                            var result = await ContentRenderer.ToRazorAsync (item);
-                            
-                            // If result.Body is null, the frame was missing - skip writing the file
-                            if (result.Body == null)
-                            {
-                                _buildErrors.AddError(item.Node.Source.RootRelativePath,
-                                    $"Frame template not found. File skipped.", null);
-                                Console.WriteLine($"\tSKIPPED (missing frame): {item.Node.Title}");
-                                return null;
-                            }
-                            
-                            await item.Node.Target.WriteContentAsync (result.Body);
-
-                            return result;
-                        }
-                        catch (Exception ex)
-                        {
-                            _buildErrors.AddError(item.Node.Source.RootRelativePath, 
-                                $"Failed to render frame for content", ex);
-                            Console.WriteLine($"\tERROR frame rendering: {item.Node.Title}");
-                            return null;
-                        }
-                            
-                    }));
+                    tasks.Add (RenderFrameAsync (item));
                 }
 
-                Task.WaitAll (tasks.ToArray ());
+                await Task.WhenAll (tasks);
                 
                 // Generate sitemap files after all content is processed
                 await GenerateSitemapsAsync(area, config);
@@ -240,6 +173,8 @@ namespace Chloroplast.Tool.Commands
                         Console.Error.WriteLine($"Failed to write error log: {ex.Message}");
                     }
                 }
+
+                throw new ChloroplastException ($"Build failed with {_buildErrors.ErrorCount} error(s).");
             }
 
             // Run validation after build completes
@@ -253,7 +188,56 @@ namespace Chloroplast.Tool.Commands
                 validator.WriteIssuesToConsole();
             }
 
-            return tasks;
+            return tasks.Cast<Task> ();
+        }
+
+        private async Task<RenderedContent> ProcessContentItemAsync (ContentNode item, IConfigurationRoot config)
+        {
+            try
+            {
+                Console.WriteLine ($"\tdoc: {item.Source.RootRelativePath}");
+
+                if (item.Source.RootRelativePath.EndsWith (".md"))
+                {
+                    var rendered = await ContentRenderer.FromMarkdownAsync (item);
+                    return await ContentRenderer.ToRazorAsync (rendered);
+                }
+
+                if (item.Source.RootRelativePath.EndsWith (".xml"))
+                {
+                    return await ContentRenderer.FromEcmaXmlAsync (item, config);
+                }
+
+                item.Source.CopyTo (item.Target);
+                return null;
+            }
+            catch (Exception ex)
+            {
+                _buildErrors.AddError (item.Source.RootRelativePath,
+                    "Failed to process content file", ex);
+                Console.WriteLine ($"\tERROR processing: {item.Source.RootRelativePath}");
+                return null;
+            }
+        }
+
+        private async Task<RenderedContent> RenderFrameAsync (FrameRenderedContent item)
+        {
+            try
+            {
+                Console.WriteLine ($"\tframe rendering: {item.Node.Title}");
+
+                var result = await ContentRenderer.ToRazorAsync (item);
+                await item.Node.Target.WriteContentAsync (result.Body);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _buildErrors.AddError (item.Node.Source.RootRelativePath,
+                    "Failed to render frame for content", ex);
+                Console.WriteLine ($"\tERROR frame rendering: {item.Node.Title}");
+                return null;
+            }
         }
 
         private void ClearOutputDirectory(IConfigurationRoot config)

--- a/toolsrc/Chloroplast.Tool/Program.cs
+++ b/toolsrc/Chloroplast.Tool/Program.cs
@@ -40,6 +40,7 @@ namespace Chloroplast.Tool
                 else
                 {
                     Console.Error.WriteLine ("config not found");
+                    Environment.ExitCode = 1;
                     return;
                 }
             }
@@ -77,13 +78,14 @@ namespace Chloroplast.Tool
                 stopwatch.Start ();
 
                 Console.WriteLine ($"Running {command.Name} command");
-                var childTasks = await command.RunAsync (config);
-                Task.WaitAll(childTasks.ToArray());
+                var childTasks = (await command.RunAsync (config)).ToArray ();
+                await Task.WhenAll (childTasks);
                 
                 // Check for any unhandled faulted tasks (but be less verbose since we now collect errors)
                 var faultedTasks = childTasks.Where(t => t.Status == TaskStatus.Faulted).ToArray();
                 if (faultedTasks.Any())
                 {
+                    Environment.ExitCode = 1;
                     Console.Error.WriteLine($"Build completed with {faultedTasks.Length} task failure(s).");
                     
                     // Only show detailed task exceptions if it's not a build command (which handles its own errors)
@@ -101,11 +103,13 @@ namespace Chloroplast.Tool
             }
             catch (ChloroplastException cex)
             {
+                Environment.ExitCode = 1;
                 Console.Error.WriteLine ($"Unable to complete {command.Name}");
                 Console.Error.WriteLine (cex.Message);
             }
             catch (Exception ex)
             {
+                Environment.ExitCode = 1;
                 Console.Error.WriteLine ($"Oops, this was unexpected :(");
                 Console.Error.WriteLine (ex.ToString());
                 if (ex.InnerException != null)


### PR DESCRIPTION
## Summary
- restore the RazorLight migration on a dedicated branch baseline
- preserve backward compatibility for legacy templates that still import `MiniRazor` / use `RawString`
- convert the built-in menu template to RazorLight-native syntax
- make `chloroplast build` fail with a non-zero exit when render/build errors occur
- fix the async build path so frame rendering and file writes are fully awaited
- update English and Spanish template guidance to reflect the new recommended authoring model

## Validation
- dotnet build --configuration Release toolsrc
- dotnet test toolsrc
- build the real docs site successfully
- verify a deliberately broken template causes `chloroplast build` to exit 1