### PR TITLE
Fix build-and-publish Node 20 action deprecations

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -15,9 +15,9 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: 8.0.x
     - name: Calculate version
@@ -40,7 +40,7 @@ jobs:
         dotnet ../toolsrc/Chloroplast.Tool/bin/Release/net8.0/Chloroplast.Tool.dll build
         echo "Documentation build completed successfully"
     - name: Upload Documentation Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: documentation
         path: docs/out


### PR DESCRIPTION
## Summary
- upgrade `actions/checkout` from `v4` to `v5`
- upgrade `actions/setup-dotnet` from `v4` to `v5`
- upgrade `actions/upload-artifact` from `v4` to `v6` so `build-and-publish` no longer depends on the deprecated Node.js 20 runtime

## Validation
- `dotnet restore toolsrc`
- `dotnet build --configuration Release --no-restore toolsrc`
- `dotnet test --no-restore --verbosity normal toolsrc`
- `cd docs && dotnet ../toolsrc/Chloroplast.Tool/bin/Release/net8.0/Chloroplast.Tool.dll build`